### PR TITLE
Fix passing opts through carbon client to oxide client

### DIFF
--- a/lib/clients/carbon_client.js
+++ b/lib/clients/carbon_client.js
@@ -3,7 +3,7 @@ var util = require('util'),
     Metric = require('../metrics/metric.js');
 
 function CarbonClient (opts) {
-  OxideClient.call(this);
+  OxideClient.call(this, opts);
 }
 util.inherits(CarbonClient, OxideClient);
 


### PR DESCRIPTION
Fixed small mistake, we could only ever connect to localhost! 